### PR TITLE
fix: real-time fetch Slide Navigator

### DIFF
--- a/src/components/Presentation/PresentationHeader/ObjectCreator/ImageUploader/UploadModal/index.jsx
+++ b/src/components/Presentation/PresentationHeader/ObjectCreator/ImageUploader/UploadModal/index.jsx
@@ -21,6 +21,7 @@ function useCreateObjectMutation(slideIdParam) {
       return data;
     },
     onSuccess: () => {
+      queryClient.invalidateQueries("slides");
       queryClient.invalidateQueries(["objects", slideIdParam]);
     },
   });

--- a/src/components/Presentation/PresentationHeader/ObjectCreator/ShapeCreator/ShapeSelector/index.jsx
+++ b/src/components/Presentation/PresentationHeader/ObjectCreator/ShapeCreator/ShapeSelector/index.jsx
@@ -22,6 +22,7 @@ function useCreateObjectMutation(slideIdParam) {
       return data;
     },
     onSuccess: () => {
+      queryClient.invalidateQueries("slides");
       queryClient.invalidateQueries(["objects", slideIdParam]);
     },
   });

--- a/src/components/Presentation/PresentationHeader/ObjectCreator/TextBoxCreator/index.jsx
+++ b/src/components/Presentation/PresentationHeader/ObjectCreator/TextBoxCreator/index.jsx
@@ -18,6 +18,7 @@ function useCreateObjectMutation(slideIdParam) {
       return data;
     },
     onSuccess: () => {
+      queryClient.invalidateQueries("slides");
       queryClient.invalidateQueries(["objects", slideIdParam]);
     },
   });

--- a/src/components/Presentation/SlideCanvasLayout/SlideCanvas/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/SlideCanvas/index.jsx
@@ -5,18 +5,15 @@ function SlideCanvas({ canvasSpec, objects, selectObject, selectedObjectId }) {
   return (
     <Canvas spec={canvasSpec}>
       {objects &&
-        objects.map((object) => {
-          console.log(`Object id: ${object._id}, type: ${object.type}`);
-          return (
-            <Object
-              key={object._id}
-              id={object._id}
-              type={object.type}
-              selectObject={selectObject}
-              selectedObjectId={selectedObjectId}
-            />
-          );
-        })}
+        objects.map((object) => (
+          <Object
+            key={object._id}
+            id={object._id}
+            type={object.type}
+            selectObject={selectObject}
+            selectedObjectId={selectedObjectId}
+          />
+        ))}
     </Canvas>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ThemeProvider } from "styled-components";
 import GlobalStyle from "./styles/GlobalStyle";
-import { ObjectProvider } from "./Contexts/Objectcontext";
+import { ObjectProvider } from "./Contexts/ObjectContext";
 
 import App from "./App";
 import appTheme from "./styles/appTheme";

--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -4,7 +4,7 @@ const { VITE_PEACHPITCH_SERVER_URI } = import.meta.env;
 
 const axiosInstance = axios.create({
   baseURL: VITE_PEACHPITCH_SERVER_URI,
-  timeout: 1000,
+  timeout: 3000,
 });
 
 export default axiosInstance;


### PR DESCRIPTION
## 개요
도형 생성 시 slide navigator에도 표시


## 작업사항
- 기존 presentation에서 prop으로 전달하던 slides 방식
    -  도형 추가시 query가 만료되어도, slideNavigator의 slides가 갱신되지 않았던 문제  발생
   
- SlideNavigator에서 useGetAllSlidesQuery 커스텀 훅으로, 컴포넌트 내에서 슬라이드들을 fetch
    - 도형 추가와 동시에 서버에 저장된 slides의 정보를 seGetAllSlidesQuery로 즉시 랜더링

- Textbox, image, shape에서 도형 추가시 muation으로 서버에 요청을 보내고, onSucess일 경우에 쿼리 무효화 => 해당 쿼리 키를 가진 useQuery 재랜더링

## 변경로직
- 내용을 적어주세요.
