### PR TITLE
feature: save coordinates and dimensions about Circle, Triangle, Square

### DIFF
--- a/src/components/Presentation/AnimationEditor/OrderEditor/index.jsx
+++ b/src/components/Presentation/AnimationEditor/OrderEditor/index.jsx
@@ -171,7 +171,7 @@ function OrderEditor() {
             </List>
             {contextMenu.visible && (
               <ContextMenu style={{ top: contextMenu.y, left: contextMenu.x }}>
-                <MenuItem onClick={handleDeleteAnimation}>삭제</MenuItem>
+                <MenuItem onClick={handleDeleteAnimation}>Delete</MenuItem>
               </ContextMenu>
             )}
           </Wrapper>

--- a/src/components/Presentation/ObjectEditor/StyleEditor/ArrangeEditor/index.jsx
+++ b/src/components/Presentation/ObjectEditor/StyleEditor/ArrangeEditor/index.jsx
@@ -10,7 +10,7 @@ function getUser() {
   return loggedInUser;
 }
 const user = getUser();
-const userId = user._id;
+const userId = user?._id;
 
 function useGetSlidesQuery() {
   const { presentationId, slideId } = useParams();

--- a/src/components/Presentation/SlideCanvasLayout/Object/Circle/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Circle/index.jsx
@@ -51,7 +51,7 @@ function Circle({ id, spec, onContextMenu }) {
       const objectId = circleSpec._id;
       const response = await axiosInstance.put(
         `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
-        { spec: updatedCircleSpec },
+        updatedCircleSpec,
       );
 
       return response.data;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Circle/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Circle/index.jsx
@@ -1,22 +1,25 @@
 import { useState, useEffect, useCallback, useContext } from "react";
 import styled from "styled-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { throttle } from "lodash";
 import Boundary from "../Boundary";
 import { ObjectContext } from "../../../../../contexts/ObjectContext";
+import axiosInstance from "../../../../../services/axios";
 
-const StyledCircle = styled.div`
-  position: absolute;
-  left: ${({ spec }) => spec.x}px;
-  top: ${({ spec }) => spec.y}px;
-  width: ${({ spec }) => spec.width}px;
-  height: ${({ spec }) => spec.height}px;
-  background-color: ${({ spec }) => spec.fillColor};
-  border: 1px solid ${({ spec }) => spec.borderColor};
-  border-radius: 100%;
-`;
+function getUser() {
+  const loggedInUser = JSON.parse(localStorage.getItem("userInfo"));
+
+  return loggedInUser;
+}
 
 function Circle({ id, spec, onContextMenu }) {
   const [boundaryVertices, setBoundaryVertices] = useState([]);
   const [circleSpec, setCircleSpec] = useState(spec);
+  const user = getUser();
+  const userId = user._id;
+  const { presentationId, slideId } = useParams();
+  const queryClient = useQueryClient();
 
   const { selectedObjectId, selectedObjectType, selectObject } =
     useContext(ObjectContext);
@@ -29,6 +32,37 @@ function Circle({ id, spec, onContextMenu }) {
     selectObject(id, spec.type);
   };
 
+  const updatedCircleSpec = {
+    type: circleSpec.type,
+    coordinates: { x: circleSpec.x, y: circleSpec.y },
+    dimensions: { width: circleSpec.width, height: circleSpec.height },
+    boundaryVertices: circleSpec.boundaryVerticles,
+    currentAnimation: circleSpec.currentAnimation,
+    _id: circleSpec._id,
+    Circle: {
+      radius: circleSpec.radius,
+      fillColor: circleSpec.fillColor,
+      borderColor: circleSpec.borderColor,
+    },
+  };
+
+  const updateCircleSpec = useMutation(
+    async () => {
+      const objectId = circleSpec._id;
+      const response = await axiosInstance.put(
+        `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
+        { spec: updatedCircleSpec },
+      );
+
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("slides");
+      },
+    },
+  );
+
   const onVertexDrag = useCallback(
     (draggedVertexIndex) => (event) => {
       event.preventDefault();
@@ -37,7 +71,7 @@ function Circle({ id, spec, onContextMenu }) {
       const initialPosition = { x: event.clientX, y: event.clientY };
       const initialSpec = { ...circleSpec };
 
-      const moveHandler = (moveEvent) => {
+      const moveHandler = throttle((moveEvent) => {
         const newPosition = {
           x: moveEvent.clientX,
           y: moveEvent.clientY,
@@ -82,6 +116,13 @@ function Circle({ id, spec, onContextMenu }) {
         }
 
         setCircleSpec(newCircleSpec);
+      }, 200);
+
+      const upHandler = async () => {
+        document.removeEventListener("mousemove", moveHandler);
+        document.removeEventListener("mouseup", upHandler);
+
+        await updateCircleSpec.mutateAsync();
       };
 
       document.addEventListener("mousemove", moveHandler);
@@ -93,7 +134,7 @@ function Circle({ id, spec, onContextMenu }) {
         { once: true },
       );
     },
-    [circleSpec],
+    [circleSpec, updateCircleSpec],
   );
 
   const onCircleDrag = (event) => {
@@ -104,21 +145,23 @@ function Circle({ id, spec, onContextMenu }) {
       y: event.clientY - circleSpec.y,
     };
 
-    function moveHandler(moveEvent) {
+    const moveHandler = throttle((moveEvent) => {
       setCircleSpec((prevSpec) => ({
         ...prevSpec,
         x: moveEvent.clientX - initialPosition.x,
         y: moveEvent.clientY - initialPosition.y,
       }));
-    }
+    }, 150);
 
-    function upHandler() {
+    const upHandler = async () => {
       document.removeEventListener("mousemove", moveHandler);
       document.removeEventListener("mouseup", upHandler);
-    }
+
+      await updateCircleSpec.mutateAsync();
+    };
 
     document.addEventListener("mousemove", moveHandler);
-    document.addEventListener("mouseup", upHandler);
+    document.addEventListener("mouseup", upHandler, { once: true });
   };
 
   useEffect(() => {
@@ -173,5 +216,16 @@ function Circle({ id, spec, onContextMenu }) {
     </div>
   );
 }
+
+const StyledCircle = styled.div`
+  position: absolute;
+  left: ${({ spec }) => spec.x}px;
+  top: ${({ spec }) => spec.y}px;
+  width: ${({ spec }) => spec.width}px;
+  height: ${({ spec }) => spec.height}px;
+  background-color: ${({ spec }) => spec.fillColor};
+  border: 1px solid ${({ spec }) => spec.borderColor};
+  border-radius: 100%;
+`;
 
 export default Circle;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Image/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Image/index.jsx
@@ -1,23 +1,16 @@
 import { useState, useEffect, useCallback, useContext } from "react";
 import styled from "styled-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { throttle } from "lodash";
 import Boundary from "../Boundary";
 import { ObjectContext } from "../../../../../contexts/ObjectContext";
+import axiosInstance from "../../../../../services/axios";
 
-const StyledImageBox = styled.div`
-  position: absolute;
-  left: ${({ spec }) => spec.x}px;
-  top: ${({ spec }) => spec.y}px;
-  width: ${({ spec }) => spec.width}px;
-  height: ${({ spec }) => spec.height}px;
-  border: 1px solid ${({ spec }) => spec.borderColor};
-  user-select: none;
-`;
-
-const StyledImage = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
+function getUser() {
+  const loggedInUser = JSON.parse(localStorage.getItem("userInfo"));
+  return loggedInUser;
+}
 
 function StyledImageComponent({ spec }) {
   return (
@@ -30,7 +23,10 @@ function StyledImageComponent({ spec }) {
 function Image({ id, spec, onContextMenu }) {
   const [boundaryVertices, setBoundaryVertices] = useState([]);
   const [imageSpec, setImageSpec] = useState(spec);
-
+  const user = getUser();
+  const userId = user._id;
+  const { presentationId, slideId } = useParams();
+  const queryClient = useQueryClient();
   const { selectedObjectId, selectedObjectType, selectObject } =
     useContext(ObjectContext);
 
@@ -42,6 +38,34 @@ function Image({ id, spec, onContextMenu }) {
     selectObject(id, spec.type);
   };
 
+  const updatedImageSpec = {
+    type: imageSpec.type,
+    coordinates: { x: imageSpec.x, y: imageSpec.y },
+    dimensions: { width: imageSpec.width, height: imageSpec.height },
+    boundaryVertices: imageSpec.boundaryVerticles,
+    currentAnimation: imageSpec.currentAnimation,
+    _id: imageSpec._id,
+    Image: {
+      imageUrl: imageSpec.fillColor,
+      borderColor: imageSpec.borderColor,
+    },
+  };
+  const updateImageSpec = useMutation(
+    async () => {
+      const objectId = imageSpec._id;
+      const response = await axiosInstance.put(
+        `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
+        updatedImageSpec,
+      );
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("slides");
+      },
+    },
+  );
+
   const onVertexDrag = useCallback(
     (draggedVertexIndex) => (event) => {
       event.preventDefault();
@@ -50,7 +74,7 @@ function Image({ id, spec, onContextMenu }) {
       const initialPosition = { x: event.clientX, y: event.clientY };
       const initialSpec = { ...imageSpec };
 
-      function moveHandler(moveEvent) {
+      const moveHandler = throttle((moveEvent) => {
         const newPosition = {
           x: moveEvent.clientX,
           y: moveEvent.clientY,
@@ -87,7 +111,13 @@ function Image({ id, spec, onContextMenu }) {
         }
 
         setImageSpec(newImageSpec);
-      }
+      }, 200);
+
+      const upHandler = async () => {
+        document.removeEventListener("mousemove", moveHandler);
+        document.removeEventListener("mouseup", upHandler);
+        await updateImageSpec.mutateAsync();
+      };
 
       document.addEventListener("mousemove", moveHandler);
       document.addEventListener(
@@ -98,7 +128,7 @@ function Image({ id, spec, onContextMenu }) {
         { once: true },
       );
     },
-    [imageSpec],
+    [imageSpec, updateImageSpec],
   );
 
   function onImageDrag(event) {
@@ -110,18 +140,19 @@ function Image({ id, spec, onContextMenu }) {
       y: event.clientY - imageSpec.y,
     };
 
-    function moveHandler(moveEvent) {
+    const moveHandler = throttle((moveEvent) => {
       setImageSpec((prevSpec) => ({
         ...prevSpec,
         x: moveEvent.clientX - initialPosition.x,
         y: moveEvent.clientY - initialPosition.y,
       }));
-    }
+    }, 150);
 
-    function upHandler() {
+    const upHandler = async () => {
       document.removeEventListener("mousemove", moveHandler);
       document.removeEventListener("mouseup", upHandler);
-    }
+      await updateImageSpec.mutateAsync();
+    };
 
     document.addEventListener("mousemove", moveHandler);
     document.addEventListener("mouseup", upHandler);
@@ -179,5 +210,21 @@ function Image({ id, spec, onContextMenu }) {
     </div>
   );
 }
+
+const StyledImageBox = styled.div`
+  position: absolute;
+  left: ${({ spec }) => spec.x}px;
+  top: ${({ spec }) => spec.y}px;
+  width: ${({ spec }) => spec.width}px;
+  height: ${({ spec }) => spec.height}px;
+  border: 1px solid ${({ spec }) => spec.borderColor};
+  user-select: none;
+`;
+
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
 
 export default Image;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
@@ -43,7 +43,7 @@ function Square({ id, spec, onContextMenu }) {
       const objectId = squareSpec._id;
       const response = await axiosInstance.put(
         `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
-        { spec: updatedSquareSpec },
+        updatedSquareSpec,
       );
       return response.data;
     },

--- a/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
@@ -1,51 +1,72 @@
 import { useState, useEffect, useCallback, useContext } from "react";
 import styled from "styled-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { throttle } from "lodash";
 import Boundary from "../Boundary";
 import { ObjectContext } from "../../../../../contexts/ObjectContext";
+import axiosInstance from "../../../../../services/axios";
 
-const StyledSquare = styled.div`
-  position: absolute;
-  left: ${({ spec }) => spec.x}px;
-  top: ${({ spec }) => spec.y}px;
-  width: ${({ spec }) => spec.width}px;
-  height: ${({ spec }) => spec.height}px;
-  background-color: ${({ spec }) => spec.fillColor};
-  border: 1px solid ${({ spec }) => spec.borderColor};
-`;
-
+function getUser() {
+  const loggedInUser = JSON.parse(localStorage.getItem("userInfo"));
+  return loggedInUser;
+}
 function Square({ id, spec, onContextMenu }) {
   const [boundaryVertices, setBoundaryVertices] = useState([]);
   const [squareSpec, setSquareSpec] = useState(spec);
-
+  const user = getUser();
+  const userId = user._id;
+  const { presentationId, slideId } = useParams();
+  const queryClient = useQueryClient();
   const { selectedObjectId, selectedObjectType, selectObject } =
     useContext(ObjectContext);
-
   const isSelected =
     id === selectedObjectId && spec.type === selectedObjectType;
-
   const handleSquareClick = (event) => {
     event.stopPropagation();
     selectObject(id, spec.type);
   };
-
+  const updatedSquareSpec = {
+    type: squareSpec.type,
+    coordinates: { x: squareSpec.x, y: squareSpec.y },
+    dimensions: { width: squareSpec.width, height: squareSpec.height },
+    boundaryVertices: squareSpec.boundaryVerticles,
+    currentAnimation: squareSpec.currentAnimation,
+    _id: squareSpec._id,
+    Square: {
+      fillColor: squareSpec.fillColor,
+      borderColor: squareSpec.borderColor,
+    },
+  };
+  const updateSquareSpec = useMutation(
+    async () => {
+      const objectId = squareSpec._id;
+      const response = await axiosInstance.put(
+        `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
+        { spec: updatedSquareSpec },
+      );
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("slides");
+      },
+    },
+  );
   const onVertexDrag = useCallback(
     (draggedVertexIndex) => (event) => {
       event.preventDefault();
       event.stopPropagation();
-
       const initialPosition = { x: event.clientX, y: event.clientY };
       const initialSpec = { ...squareSpec };
-
-      function moveHandler(moveEvent) {
+      const moveHandler = throttle((moveEvent) => {
         const newPosition = {
           x: moveEvent.clientX,
           y: moveEvent.clientY,
         };
-
         let newSquareSpec = { ...squareSpec };
         const heightChange = newPosition.y - initialPosition.y;
         const widthChange = newPosition.x - initialPosition.x;
-
         switch (draggedVertexIndex) {
           case 0:
             newSquareSpec = {
@@ -108,10 +129,13 @@ function Square({ id, spec, onContextMenu }) {
           default:
             break;
         }
-
         setSquareSpec(newSquareSpec);
-      }
-
+      }, 200);
+      const upHandler = async () => {
+        document.removeEventListener("mousemove", moveHandler);
+        document.removeEventListener("mouseup", upHandler);
+        await updateSquareSpec.mutateAsync();
+      };
       document.addEventListener("mousemove", moveHandler);
       document.addEventListener(
         "mouseup",
@@ -121,41 +145,34 @@ function Square({ id, spec, onContextMenu }) {
         { once: true },
       );
     },
-    [squareSpec],
+    [squareSpec, updateSquareSpec],
   );
-
   const onSquareDrag = (event) => {
     event.stopPropagation();
-
     const initialPosition = {
       x: event.clientX - squareSpec.x,
       y: event.clientY - squareSpec.y,
     };
-
-    function moveHandler(moveEvent) {
+    const moveHandler = throttle((moveEvent) => {
       setSquareSpec((prevSpec) => ({
         ...prevSpec,
         x: moveEvent.clientX - initialPosition.x,
         y: moveEvent.clientY - initialPosition.y,
       }));
-    }
-
-    function upHandler() {
+    }, 150);
+    const upHandler = async () => {
       document.removeEventListener("mousemove", moveHandler);
       document.removeEventListener("mouseup", upHandler);
-    }
-
+      await updateSquareSpec.mutateAsync();
+    };
     document.addEventListener("mousemove", moveHandler);
-    document.addEventListener("mouseup", upHandler);
+    document.addEventListener("mouseup", upHandler, { once: true });
   };
-
   useEffect(() => {
     setSquareSpec(spec);
   }, [spec]);
-
   useEffect(() => {
     const offset = { x: 1, y: 1 };
-
     const baseVertices = [
       { x: squareSpec.x, y: squareSpec.y },
       { x: squareSpec.x + squareSpec.width / 2, y: squareSpec.y },
@@ -175,15 +192,12 @@ function Square({ id, spec, onContextMenu }) {
       { x: squareSpec.x, y: squareSpec.y + squareSpec.height },
       { x: squareSpec.x, y: squareSpec.y + squareSpec.height / 2 },
     ];
-
     const updatedBoundaryVertices = baseVertices.map((vertex) => ({
       x: vertex.x + offset.x,
       y: vertex.y + offset.y,
     }));
-
     setBoundaryVertices(updatedBoundaryVertices);
   }, [squareSpec]);
-
   return (
     <div
       onClick={handleSquareClick}
@@ -201,5 +215,13 @@ function Square({ id, spec, onContextMenu }) {
     </div>
   );
 }
-
+const StyledSquare = styled.div`
+  position: absolute;
+  left: ${({ spec }) => spec.x}px;
+  top: ${({ spec }) => spec.y}px;
+  width: ${({ spec }) => spec.width}px;
+  height: ${({ spec }) => spec.height}px;
+  background-color: ${({ spec }) => spec.fillColor};
+  border: 1px solid ${({ spec }) => spec.borderColor};
+`;
 export default Square;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Square/index.jsx
@@ -11,6 +11,7 @@ function getUser() {
   const loggedInUser = JSON.parse(localStorage.getItem("userInfo"));
   return loggedInUser;
 }
+
 function Square({ id, spec, onContextMenu }) {
   const [boundaryVertices, setBoundaryVertices] = useState([]);
   const [squareSpec, setSquareSpec] = useState(spec);
@@ -20,12 +21,15 @@ function Square({ id, spec, onContextMenu }) {
   const queryClient = useQueryClient();
   const { selectedObjectId, selectedObjectType, selectObject } =
     useContext(ObjectContext);
+
   const isSelected =
     id === selectedObjectId && spec.type === selectedObjectType;
+
   const handleSquareClick = (event) => {
     event.stopPropagation();
     selectObject(id, spec.type);
   };
+
   const updatedSquareSpec = {
     type: squareSpec.type,
     coordinates: { x: squareSpec.x, y: squareSpec.y },
@@ -53,20 +57,24 @@ function Square({ id, spec, onContextMenu }) {
       },
     },
   );
+
   const onVertexDrag = useCallback(
     (draggedVertexIndex) => (event) => {
       event.preventDefault();
       event.stopPropagation();
       const initialPosition = { x: event.clientX, y: event.clientY };
       const initialSpec = { ...squareSpec };
+
       const moveHandler = throttle((moveEvent) => {
         const newPosition = {
           x: moveEvent.clientX,
           y: moveEvent.clientY,
         };
+
         let newSquareSpec = { ...squareSpec };
         const heightChange = newPosition.y - initialPosition.y;
         const widthChange = newPosition.x - initialPosition.x;
+
         switch (draggedVertexIndex) {
           case 0:
             newSquareSpec = {
@@ -131,11 +139,13 @@ function Square({ id, spec, onContextMenu }) {
         }
         setSquareSpec(newSquareSpec);
       }, 200);
+
       const upHandler = async () => {
         document.removeEventListener("mousemove", moveHandler);
         document.removeEventListener("mouseup", upHandler);
         await updateSquareSpec.mutateAsync();
       };
+
       document.addEventListener("mousemove", moveHandler);
       document.addEventListener(
         "mouseup",
@@ -147,12 +157,15 @@ function Square({ id, spec, onContextMenu }) {
     },
     [squareSpec, updateSquareSpec],
   );
+
   const onSquareDrag = (event) => {
     event.stopPropagation();
+
     const initialPosition = {
       x: event.clientX - squareSpec.x,
       y: event.clientY - squareSpec.y,
     };
+
     const moveHandler = throttle((moveEvent) => {
       setSquareSpec((prevSpec) => ({
         ...prevSpec,
@@ -160,19 +173,24 @@ function Square({ id, spec, onContextMenu }) {
         y: moveEvent.clientY - initialPosition.y,
       }));
     }, 150);
+
     const upHandler = async () => {
       document.removeEventListener("mousemove", moveHandler);
       document.removeEventListener("mouseup", upHandler);
       await updateSquareSpec.mutateAsync();
     };
+
     document.addEventListener("mousemove", moveHandler);
     document.addEventListener("mouseup", upHandler, { once: true });
   };
+
   useEffect(() => {
     setSquareSpec(spec);
   }, [spec]);
+
   useEffect(() => {
     const offset = { x: 1, y: 1 };
+
     const baseVertices = [
       { x: squareSpec.x, y: squareSpec.y },
       { x: squareSpec.x + squareSpec.width / 2, y: squareSpec.y },
@@ -196,8 +214,10 @@ function Square({ id, spec, onContextMenu }) {
       x: vertex.x + offset.x,
       y: vertex.y + offset.y,
     }));
+
     setBoundaryVertices(updatedBoundaryVertices);
   }, [squareSpec]);
+
   return (
     <div
       onClick={handleSquareClick}
@@ -215,6 +235,7 @@ function Square({ id, spec, onContextMenu }) {
     </div>
   );
 }
+
 const StyledSquare = styled.div`
   position: absolute;
   left: ${({ spec }) => spec.x}px;
@@ -224,4 +245,5 @@ const StyledSquare = styled.div`
   background-color: ${({ spec }) => spec.fillColor};
   border: 1px solid ${({ spec }) => spec.borderColor};
 `;
+
 export default Square;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Triangle/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Triangle/index.jsx
@@ -1,22 +1,24 @@
 import { useState, useEffect, useCallback, useContext } from "react";
 import styled from "styled-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { throttle } from "lodash";
 import Boundary from "../Boundary";
 import { ObjectContext } from "../../../../../contexts/ObjectContext";
+import axiosInstance from "../../../../../services/axios";
 
-const StyledTriangle = styled.div`
-  position: absolute;
-  width: ${({ spec }) => spec.width}px;
-  height: ${({ spec }) => spec.height}px;
-  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-  background-color: ${({ spec }) => spec.fillColor};
-  border: 1px solid ${({ spec }) => spec.borderColor};
-  top: ${({ spec }) => spec.y}px;
-  left: ${({ spec }) => spec.x}px;
-`;
+function getUser() {
+  const loggedInUser = JSON.parse(localStorage.getItem("userInfo"));
+  return loggedInUser;
+}
 
 function Triangle({ id, spec, onContextMenu }) {
   const [boundaryVertices, setBoundaryVertices] = useState([]);
   const [triangleSpec, setTriangleSpec] = useState(spec);
+  const user = getUser();
+  const userId = user._id;
+  const { presentationId, slideId } = useParams();
+  const queryClient = useQueryClient();
 
   const { selectedObjectId, selectedObjectType, selectObject } =
     useContext(ObjectContext);
@@ -29,6 +31,39 @@ function Triangle({ id, spec, onContextMenu }) {
     selectObject(id, spec.type);
   };
 
+  const updatedTriangleSpec = {
+    type: triangleSpec.type,
+    coordinates: { x: triangleSpec.x, y: triangleSpec.y },
+    dimensions: { width: triangleSpec.width, height: triangleSpec.height },
+    boundaryVertices: triangleSpec.boundaryVerticles,
+    currentAnimation: triangleSpec.currentAnimation,
+    _id: triangleSpec._id,
+    Triangle: {
+      verticles: triangleSpec.verticles,
+      x: triangleSpec.x,
+      y: triangleSpec.y,
+      width: triangleSpec.width,
+      height: triangleSpec.height,
+      fillColor: triangleSpec.fillColor,
+      borderColor: triangleSpec.borderColor,
+    },
+  };
+  const updateTriangleSpec = useMutation(
+    async () => {
+      const objectId = triangleSpec._id;
+      const response = await axiosInstance.put(
+        `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
+        { spec: updatedTriangleSpec },
+      );
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("slides");
+      },
+    },
+  );
+
   const onVertexDrag = useCallback(
     (draggedVertexIndex) => (event) => {
       event.preventDefault();
@@ -37,7 +72,7 @@ function Triangle({ id, spec, onContextMenu }) {
       const initialPosition = { x: event.clientX, y: event.clientY };
       const initialSpec = { ...triangleSpec };
 
-      function moveHandler(moveEvent) {
+      const moveHandler = throttle((moveEvent) => {
         const newPosition = {
           x: moveEvent.clientX,
           y: moveEvent.clientY,
@@ -111,7 +146,13 @@ function Triangle({ id, spec, onContextMenu }) {
         }
 
         setTriangleSpec(newTriangleSpec);
-      }
+      }, 200);
+
+      const upHandler = async () => {
+        document.removeEventListener("mousemove", moveHandler);
+        document.removeEventListener("mouseup", upHandler);
+        await updateTriangleSpec.mutateAsync();
+      };
 
       document.addEventListener("mousemove", moveHandler);
       document.addEventListener(
@@ -122,7 +163,7 @@ function Triangle({ id, spec, onContextMenu }) {
         { once: true },
       );
     },
-    [triangleSpec],
+    [triangleSpec, updateTriangleSpec],
   );
 
   function onTriangleDrag(event) {
@@ -133,18 +174,20 @@ function Triangle({ id, spec, onContextMenu }) {
       y: event.clientY - triangleSpec.y,
     };
 
-    function moveHandler(moveEvent) {
+    const moveHandler = throttle((moveEvent) => {
       setTriangleSpec((prevSpec) => ({
         ...prevSpec,
         x: moveEvent.clientX - initialPosition.x,
         y: moveEvent.clientY - initialPosition.y,
       }));
-    }
+    }, 150);
 
-    function upHandler() {
+    const upHandler = async () => {
       document.removeEventListener("mousemove", moveHandler);
       document.removeEventListener("mouseup", upHandler);
-    }
+
+      await updateTriangleSpec.mutateAsync();
+    };
 
     document.addEventListener("mousemove", moveHandler);
     document.addEventListener("mouseup", upHandler);
@@ -202,5 +245,16 @@ function Triangle({ id, spec, onContextMenu }) {
     </div>
   );
 }
+
+const StyledTriangle = styled.div`
+  position: absolute;
+  width: ${({ spec }) => spec.width}px;
+  height: ${({ spec }) => spec.height}px;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  background-color: ${({ spec }) => spec.fillColor};
+  border: 1px solid ${({ spec }) => spec.borderColor};
+  top: ${({ spec }) => spec.y}px;
+  left: ${({ spec }) => spec.x}px;
+`;
 
 export default Triangle;

--- a/src/components/Presentation/SlideCanvasLayout/Object/Triangle/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Triangle/index.jsx
@@ -53,7 +53,7 @@ function Triangle({ id, spec, onContextMenu }) {
       const objectId = triangleSpec._id;
       const response = await axiosInstance.put(
         `/users/${userId}/presentations/${presentationId}/slides/${slideId}/objects/${objectId}`,
-        { spec: updatedTriangleSpec },
+        updatedTriangleSpec,
       );
       return response.data;
     },

--- a/src/components/Presentation/SlideNavigator/index.jsx
+++ b/src/components/Presentation/SlideNavigator/index.jsx
@@ -197,8 +197,8 @@ function SlideNavigator() {
       })}
       {contextMenu.visible && (
         <ContextMenu style={{ top: contextMenu.y, left: contextMenu.x }}>
-          <MenuItem onClick={handleAddSlide}>추가</MenuItem>
-          <MenuItem onClick={handleDeleteSlide}>삭제</MenuItem>
+          <MenuItem onClick={handleAddSlide}>Add</MenuItem>
+          <MenuItem onClick={handleDeleteSlide}>Delete</MenuItem>
         </ContextMenu>
       )}
     </Wrapper>


### PR DESCRIPTION
## 개요
원, 삼각형, 사각형의 드래그 후 좌표와 리사이징 후 도형의 크기를 db에 저장

## 작업사항

### 원, 삼각형, 사각형
- 도형 별로 다른 각각의 스키마에 맞추어, 드래그 후 좌표와 리사이징 후 도형의 크기가 포함된 새로운 배열을 서버에 전송. 
- 전송받은 데이터를 서버에 보내고, 서버는 이를 db에 전송
- onSucess의 경우 queryClient.invalidateQueries("slide")를 통해 "slide" query Key를 가진 useQuery를 무효화해 재 랜더링한다. 

=> 슬라이드 미리보기도 좌표, 크기의 변화에 따라 함께 변화

<img width="1121" alt="image" src="https://github.com/Team-dtrio/peach-pitch-client/assets/80331804/8d5123b7-16af-40a6-86fa-a9827b22e2cf">

### 이미지, 텍스트 박스도 서버에 전송
- 슬라이드 미리보기에 실시간 변경 사항 표시 

<img width="1037" alt="image" src="https://github.com/Team-dtrio/peach-pitch-client/assets/80331804/5d5d3484-c568-4566-8407-09ff7d4caabc">


## 변경로직
- 내용을 적어주세요.
